### PR TITLE
Removing bcbio

### DIFF
--- a/GenBankToLib/genbank.py
+++ b/GenBankToLib/genbank.py
@@ -8,10 +8,11 @@ import re
 import binascii
 import gzip
 from Bio import SeqIO
-from BCBio import GFF  # bcbio-gff package
 import pandas as pd
 from io import StringIO
 import logging
+
+from .gff import write_gff3
 
 __author__ = 'Rob Edwards'
 __copyright__ = 'Copyright 2020, Rob Edwards'
@@ -223,7 +224,7 @@ def genbank_to_ptt(gbkf, printout=False):
             cid = feature_id(seq, feat)
 
             thisres = [
-                f"{feat.location.start}..{feat.location.end}",
+                f"{int(feat.location.start) + 1}..{int(feat.location.end)}",
                 "+" if feat.location.strand >= 0 else "-",
                 (len(feat.location) / 3) - 1,
                 gi,
@@ -366,7 +367,7 @@ def genbank_to_gff(gbkf, out_gff):
     logging.info(f"Writing gff3 to {out_gff}")
     with open(out_gff, 'w') as outf:
         seqs, handle = genbank_seqio(gbkf)
-        GFF.write(seqs, outf, True)
+        write_gff3(seqs, outf, True)
         handle.close()
 
 
@@ -380,7 +381,7 @@ def genbank_to_amrfinder(gbkf, amrout):
     logging.info(f"AMR: Converting {gbkf} to GFF3")
     gffstr = StringIO()
     seqs, handle = genbank_seqio(gbkf)
-    GFF.write(seqs, gffstr, True)
+    write_gff3(seqs, gffstr, True)
     handle.close()
     gffstr.seek(0)
 

--- a/GenBankToLib/gff.py
+++ b/GenBankToLib/gff.py
@@ -1,0 +1,205 @@
+"""
+Small GFF/GFF3 reader and writer utilities.
+"""
+from dataclasses import dataclass, field
+from typing import Iterable, Iterator, TextIO
+from urllib.parse import quote, unquote
+
+
+@dataclass
+class GFFRecord:
+    """A single GFF feature row."""
+
+    seqid: str
+    source: str
+    type: str
+    start: int
+    end: int
+    score: str = "."
+    strand: str = "."
+    phase: str = "."
+    attributes: dict[str, list[str]] = field(default_factory=dict)
+
+
+def parse_attributes(value: str, gff3: bool = True) -> dict[str, list[str]]:
+    """
+    Parse a GFF or GFF3 attribute column.
+
+    GFF3 uses key=value pairs. Older GFF files often use key value pairs, so this
+    accepts both forms.
+    """
+
+    if value == ".":
+        return {}
+
+    attributes: dict[str, list[str]] = {}
+    for item in value.rstrip().split(";"):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" in item:
+            key, raw_value = item.split("=", 1)
+        elif " " in item and not gff3:
+            key, raw_value = item.split(" ", 1)
+        else:
+            key, raw_value = item, ""
+        attributes[unquote(key)] = [unquote(v) for v in raw_value.split(",")]
+    return attributes
+
+
+def parse_gff(handle: TextIO, gff3: bool = False) -> Iterator[GFFRecord]:
+    """Yield feature rows from a GFF or GFF3 file handle."""
+
+    for line in handle:
+        if line.startswith("##FASTA"):
+            break
+        if not line.strip() or line.startswith("#"):
+            continue
+        parts = line.rstrip("\n").split("\t")
+        if len(parts) != 9:
+            raise ValueError(f"Expected 9 GFF columns, found {len(parts)}: {line.rstrip()}")
+        yield GFFRecord(
+            seqid=parts[0],
+            source=parts[1],
+            type=parts[2],
+            start=int(parts[3]),
+            end=int(parts[4]),
+            score=parts[5],
+            strand=parts[6],
+            phase=parts[7],
+            attributes=parse_attributes(parts[8], gff3=gff3),
+        )
+
+
+def parse_gff3(handle: TextIO) -> Iterator[GFFRecord]:
+    """Yield feature rows from a GFF3 file handle."""
+
+    yield from parse_gff(handle, gff3=True)
+
+
+def format_attributes(attributes: dict[str, Iterable[object]], gff3: bool = True) -> str:
+    """Format attributes for a GFF or GFF3 row."""
+
+    if not attributes:
+        return "."
+
+    items = []
+    for key in sorted(attributes):
+        raw_values = attributes[key]
+        values = list(raw_values)
+        if not values:
+            values = [""]
+        encoded_values = ",".join(_escape(value) for value in values)
+        if gff3:
+            items.append(f"{_escape(key)}={encoded_values}")
+        else:
+            items.append(f"{_escape(key)} {encoded_values}")
+    return ";".join(items)
+
+
+def write_gff(records: Iterable[GFFRecord], handle: TextIO, gff3: bool = False) -> None:
+    """Write plain GFFRecord objects as GFF or GFF3."""
+
+    if gff3:
+        handle.write("##gff-version 3\n")
+    for record in records:
+        handle.write(_format_record(record, gff3=gff3))
+
+
+def write_gff3(seq_records: Iterable[object], handle: TextIO, include_fasta: bool = True) -> None:
+    """
+    Write Biopython SeqRecord objects as GFF3.
+
+    This intentionally covers the GenBank-to-GFF path used by this package:
+    record annotations, sequence-region pragmas, feature qualifiers, and an
+    optional FASTA trailer.
+    """
+
+    records = list(seq_records)
+    handle.write("##gff-version 3\n")
+    for seq_record in records:
+        handle.write(f"##sequence-region {seq_record.id} 1 {len(seq_record.seq)}\n")
+        annotation_attributes = _annotation_attributes(seq_record)
+        if annotation_attributes:
+            annotation_record = GFFRecord(
+                seqid=seq_record.id,
+                source="annotation",
+                type="remark",
+                start=1,
+                end=len(seq_record.seq),
+                attributes=annotation_attributes,
+            )
+            handle.write(_format_record(annotation_record, gff3=True))
+        for feature in seq_record.features:
+            handle.write(_format_feature(seq_record, feature))
+
+    if include_fasta and records:
+        handle.write("##FASTA\n")
+        for seq_record in records:
+            description = getattr(seq_record, "description", "") or seq_record.id
+            handle.write(f">{seq_record.id} {description}\n")
+            sequence = str(seq_record.seq)
+            for index in range(0, len(sequence), 60):
+                handle.write(f"{sequence[index:index + 60]}\n")
+
+
+def _format_record(record: GFFRecord, gff3: bool = True) -> str:
+    return "\t".join(
+        [
+            record.seqid,
+            record.source,
+            record.type,
+            str(record.start),
+            str(record.end),
+            record.score,
+            record.strand,
+            record.phase,
+            format_attributes(record.attributes, gff3=gff3),
+        ]
+    ) + "\n"
+
+
+def _format_feature(seq_record: object, feature: object) -> str:
+    start = int(feature.location.start) + 1
+    end = int(feature.location.end)
+    strand = _strand(feature)
+    phase = "."
+    if feature.type == "CDS":
+        codon_start = feature.qualifiers.get("codon_start", ["1"])[0]
+        phase = str(int(codon_start) - 1)
+    record = GFFRecord(
+        seqid=seq_record.id,
+        source="feature",
+        type=feature.type,
+        start=start,
+        end=end,
+        strand=strand,
+        phase=phase,
+        attributes=feature.qualifiers,
+    )
+    return _format_record(record, gff3=True)
+
+
+def _annotation_attributes(seq_record: object) -> dict[str, list[object]]:
+    attributes: dict[str, list[object]] = {}
+    for key, value in seq_record.annotations.items():
+        if key == "comment" and not value:
+            continue
+        if isinstance(value, list):
+            attributes[key] = value
+        else:
+            attributes[key] = [value]
+    return attributes
+
+
+def _strand(feature: object) -> str:
+    strand = feature.location.strand
+    if strand is None:
+        return "."
+    if strand < 0:
+        return "-"
+    return "+"
+
+
+def _escape(value: object) -> str:
+    return quote(str(value).rstrip(), safe=": /")

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -73,7 +73,8 @@ genbank_to requires Python 3.9 or later and the following packages:
 - **biopython** (>=1.74): For parsing GenBank files
 - **numpy** (>=1.16.0): For numerical operations
 - **pandas**: For data manipulation
-- **bcbio-gff** (>=0.6.6): For GFF format support
+
+GFF and GFF3 reading/writing support is included in genbank_to.
 
 These dependencies will be automatically installed when you install genbank_to using any of the methods above.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "biopython>=1.74",
     "numpy>=1.16.0",
     "pandas",
-    "bcbio-gff>=0.6.6",
 ]
 
 [project.optional-dependencies]

--- a/test/outputs/NC_001417.json
+++ b/test/outputs/NC_001417.json
@@ -17,7 +17,7 @@
     },
     "features": [
         {
-            "type": "CDS",
+            "type": "cds",
             "contig": "NC_001417.2",
             "start": 130,
             "stop": 1311,
@@ -44,7 +44,7 @@
             "rbs_motif": "NA"
         },
         {
-            "type": "CDS",
+            "type": "cds",
             "contig": "NC_001417.2",
             "start": 1335,
             "stop": 1727,
@@ -107,7 +107,7 @@
             "rbs_motif": "NA"
         },
         {
-            "type": "CDS",
+            "type": "cds",
             "contig": "NC_001417.2",
             "start": 1678,
             "stop": 1905,
@@ -134,7 +134,7 @@
             "rbs_motif": "NA"
         },
         {
-            "type": "CDS",
+            "type": "cds",
             "contig": "NC_001417.2",
             "start": 1761,
             "stop": 3398,
@@ -176,6 +176,6 @@
         }
     ],
     "version": {
-        "genbank_to": "0.53"
+        "genbank_to": "0.55"
     }
 }

--- a/test/test_gff.py
+++ b/test/test_gff.py
@@ -1,0 +1,73 @@
+from io import StringIO
+
+from GenBankToLib.gff import GFFRecord, parse_gff, parse_gff3, write_gff
+
+
+def test_parse_gff3_attributes():
+    handle = StringIO(
+        "seq1\tfeature\tCDS\t1\t9\t.\t+\t0\t"
+        "ID=cds1;product=hypothetical protein;Dbxref=GeneID:1,UniProtKB/Swiss-Prot:P1\n"
+        "##FASTA\n"
+        ">seq1\n"
+        "ATGAAATAA\n"
+    )
+
+    records = list(parse_gff3(handle))
+
+    assert records == [
+        GFFRecord(
+            seqid="seq1",
+            source="feature",
+            type="CDS",
+            start=1,
+            end=9,
+            score=".",
+            strand="+",
+            phase="0",
+            attributes={
+                "ID": ["cds1"],
+                "product": ["hypothetical protein"],
+                "Dbxref": ["GeneID:1", "UniProtKB/Swiss-Prot:P1"],
+            },
+        )
+    ]
+
+
+def test_parse_gff2_attributes():
+    handle = StringIO("seq1\tfeature\tgene\t1\t9\t.\t+\t.\tgene geneA;locus_tag LT1\n")
+
+    records = list(parse_gff(handle))
+
+    assert records[0].attributes == {
+        "gene": ["geneA"],
+        "locus_tag": ["LT1"],
+    }
+
+
+def test_write_gff3_records():
+    handle = StringIO()
+    write_gff(
+        [
+            GFFRecord(
+                seqid="seq1",
+                source="feature",
+                type="CDS",
+                start=1,
+                end=9,
+                strand="+",
+                phase="0",
+                attributes={
+                    "product": ["hypothetical protein"],
+                    "Dbxref": ["GeneID:1", "UniProtKB/Swiss-Prot:P1"],
+                },
+            )
+        ],
+        handle,
+        gff3=True,
+    )
+
+    assert handle.getvalue() == (
+        "##gff-version 3\n"
+        "seq1\tfeature\tCDS\t1\t9\t.\t+\t0\t"
+        "Dbxref=GeneID:1,UniProtKB/Swiss-Prot:P1;product=hypothetical protein\n"
+    )


### PR DESCRIPTION
This pull request removes the dependency on the external `bcbio-gff` package by introducing a new in-house GFF/GFF3 parser and writer (`gff.py`). The core GenBank-to-GFF3 conversion logic now uses this new implementation, resulting in a lighter dependency footprint and more maintainable code. Documentation and tests are also updated to reflect these changes, and there are minor adjustments to output formatting.

**Migration from `bcbio-gff` to internal GFF/GFF3 support:**
- Added a new `GenBankToLib/gff.py` module implementing GFF/GFF3 parsing and writing utilities, including `GFFRecord`, `parse_gff`, `parse_gff3`, and `write_gff3` functions.
- Updated `genbank.py` to use the new `write_gff3` function instead of `GFF.write`, removing the import of `bcbio-gff` and replacing all relevant calls. [[1]](diffhunk://#diff-a98796989ee03f7e0219478269367167ea87bdd8e95e5df9c7a2e2c43b6b383aL11-R16) [[2]](diffhunk://#diff-a98796989ee03f7e0219478269367167ea87bdd8e95e5df9c7a2e2c43b6b383aL369-R370) [[3]](diffhunk://#diff-a98796989ee03f7e0219478269367167ea87bdd8e95e5df9c7a2e2c43b6b383aL383-R384)

**Dependency and documentation updates:**
- Removed `bcbio-gff` from the list of dependencies in `pyproject.toml` and updated the installation documentation to clarify that GFF/GFF3 support is now internal. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L34) [[2]](diffhunk://#diff-d9b149498982c0663c3b7170398773361ed5678f1a627e9c2fd8d2c955c563dbL76-R77)

**Testing improvements:**
- Added `test/test_gff.py` with unit tests for GFF3 parsing, GFF2 parsing, and GFF3 writing using the new internal module.

**Output and format adjustments:**
- Adjusted feature start coordinate calculation in `genbank_to_ptt` to be 1-based, ensuring consistency with GFF3 format.
- Updated test output JSON to use lowercase `"cds"` instead of `"CDS"` for feature types and incremented the reported `genbank_to` version. [[1]](diffhunk://#diff-030ca1f700622fe1caa02adb3d87d057a551c815e5a070f4c3791066eaf8d41bL20-R20) [[2]](diffhunk://#diff-030ca1f700622fe1caa02adb3d87d057a551c815e5a070f4c3791066eaf8d41bL47-R47) [[3]](diffhunk://#diff-030ca1f700622fe1caa02adb3d87d057a551c815e5a070f4c3791066eaf8d41bL110-R110) [[4]](diffhunk://#diff-030ca1f700622fe1caa02adb3d87d057a551c815e5a070f4c3791066eaf8d41bL137-R137) [[5]](diffhunk://#diff-030ca1f700622fe1caa02adb3d87d057a551c815e5a070f4c3791066eaf8d41bL179-R179)