### PR TITLE
[codex] Split compound GFF feature locations

### DIFF
--- a/GenBankToLib/gff.py
+++ b/GenBankToLib/gff.py
@@ -160,24 +160,53 @@ def _format_record(record: GFFRecord, gff3: bool = True) -> str:
 
 
 def _format_feature(seq_record: object, feature: object) -> str:
-    start = int(feature.location.start) + 1
-    end = int(feature.location.end)
-    strand = _strand(feature)
-    phase = "."
-    if feature.type == "CDS":
-        codon_start = feature.qualifiers.get("codon_start", ["1"])[0]
-        phase = str(int(codon_start) - 1)
-    record = GFFRecord(
-        seqid=seq_record.id,
-        source="feature",
-        type=feature.type,
-        start=start,
-        end=end,
-        strand=strand,
-        phase=phase,
-        attributes=feature.qualifiers,
-    )
-    return _format_record(record, gff3=True)
+    records = []
+    initial_cds_phase = _initial_cds_phase(feature)
+    cds_bases = 0
+    for part_index, part in enumerate(_location_parts(feature.location)):
+        start = int(part.start) + 1
+        end = int(part.end)
+        strand = _strand(part)
+        phase = "."
+        if feature.type == "CDS":
+            if part_index == 0:
+                phase = str(initial_cds_phase)
+                cds_bases -= initial_cds_phase
+            else:
+                phase = str((3 - (cds_bases % 3)) % 3)
+            cds_bases += len(part)
+        record = GFFRecord(
+            seqid=seq_record.id,
+            source="feature",
+            type=feature.type,
+            start=start,
+            end=end,
+            strand=strand,
+            phase=phase,
+            attributes=feature.qualifiers,
+        )
+        records.append(_format_record(record, gff3=True))
+    return "".join(records)
+
+
+def _location_parts(location: object) -> Iterable[object]:
+    return getattr(location, "parts", [location])
+
+
+def _initial_cds_phase(feature: object) -> int:
+    if feature.type != "CDS":
+        return 0
+    codon_start = feature.qualifiers.get("codon_start", ["1"])[0]
+    return int(codon_start) - 1
+
+
+def _strand(location: object) -> str:
+    strand = location.strand
+    if strand is None:
+        return "."
+    if strand < 0:
+        return "-"
+    return "+"
 
 
 def _annotation_attributes(seq_record: object) -> dict[str, list[object]]:
@@ -190,15 +219,6 @@ def _annotation_attributes(seq_record: object) -> dict[str, list[object]]:
         else:
             attributes[key] = [value]
     return attributes
-
-
-def _strand(feature: object) -> str:
-    strand = feature.location.strand
-    if strand is None:
-        return "."
-    if strand < 0:
-        return "-"
-    return "+"
 
 
 def _escape(value: object) -> str:

--- a/test/test_gff.py
+++ b/test/test_gff.py
@@ -1,6 +1,10 @@
 from io import StringIO
 
-from GenBankToLib.gff import GFFRecord, parse_gff, parse_gff3, write_gff
+from Bio.Seq import Seq
+from Bio.SeqFeature import CompoundLocation, SeqFeature, SimpleLocation
+from Bio.SeqRecord import SeqRecord
+
+from GenBankToLib.gff import GFFRecord, parse_gff, parse_gff3, write_gff, write_gff3
 
 
 def test_parse_gff3_attributes():
@@ -71,3 +75,57 @@ def test_write_gff3_records():
         "seq1\tfeature\tCDS\t1\t9\t.\t+\t0\t"
         "Dbxref=GeneID:1,UniProtKB/Swiss-Prot:P1;product=hypothetical protein\n"
     )
+
+
+def test_write_gff3_splits_compound_cds_locations():
+    seq_record = SeqRecord(Seq("N" * 300), id="seq1")
+    seq_record.features = [
+        SeqFeature(
+            CompoundLocation(
+                [
+                    SimpleLocation(0, 10, strand=1),
+                    SimpleLocation(100, 200, strand=1),
+                    SimpleLocation(250, 260, strand=1),
+                ]
+            ),
+            type="CDS",
+            qualifiers={"ID": ["cds1"], "codon_start": ["1"]},
+        )
+    ]
+    handle = StringIO()
+
+    write_gff3([seq_record], handle, include_fasta=False)
+
+    records = list(parse_gff3(StringIO(handle.getvalue())))
+    assert [(record.start, record.end, record.phase) for record in records] == [
+        (1, 10, "0"),
+        (101, 200, "2"),
+        (251, 260, "1"),
+    ]
+    assert all(record.type == "CDS" for record in records)
+    assert all(record.attributes["ID"] == ["cds1"] for record in records)
+
+
+def test_write_gff3_splits_origin_spanning_compound_locations():
+    seq_record = SeqRecord(Seq("N" * 1000), id="seq1")
+    seq_record.features = [
+        SeqFeature(
+            CompoundLocation(
+                [
+                    SimpleLocation(899, 1000, strand=1),
+                    SimpleLocation(0, 100, strand=1),
+                ]
+            ),
+            type="CDS",
+            qualifiers={"ID": ["cds_wrap"], "codon_start": ["2"]},
+        )
+    ]
+    handle = StringIO()
+
+    write_gff3([seq_record], handle, include_fasta=False)
+
+    records = list(parse_gff3(StringIO(handle.getvalue())))
+    assert [(record.start, record.end, record.phase) for record in records] == [
+        (900, 1000, "1"),
+        (1, 100, "2"),
+    ]


### PR DESCRIPTION
## Summary

This fixes GFF3 output for GenBank features whose locations are compound, including ordinary `join(...)` locations and origin-spanning compound locations. Instead of emitting one row using the outer `feature.location.start` and `.end` bounds, GFF3 output now emits one row per location part.

For CDS features, phases are calculated across the emitted parts while respecting `codon_start`, so downstream consumers do not treat intervening bases as coding sequence.

## Root Cause

The previous GFF formatter used Biopython's aggregate `feature.location.start` and `.end` values directly. For a compound location such as `join(1..10,101..200)`, those aggregate bounds describe `1..200`, which incorrectly annotates the intervening bases.

## Validation

- `pytest` passed: 16 tests
- Added focused unit coverage for split compound CDS locations and origin-spanning compound CDS locations